### PR TITLE
Allow .md relative spelling files

### DIFF
--- a/es5/cli-interactive.js
+++ b/es5/cli-interactive.js
@@ -4,7 +4,13 @@ exports.__esModule = true;
 
 exports.default = function (file, src, options, fileProcessed) {
   spellAndFixFile(file, src, options, function () {
-    _spellConfig2.default.writeFile(fileProcessed);
+    _spellConfig2.default.writeFile(function () {
+      if (options.relativeSpellingFiles) {
+        _spellConfig2.default.writeFile(fileProcessed, true);
+      } else {
+        fileProcessed();
+      }
+    });
   });
 };
 
@@ -40,14 +46,20 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var ACTION_IGNORE = "ignore";
 var ACTION_FILE_IGNORE = "fileignore";
+var ACTION_FILE_IGNORE_RELATIVE = "fileignore-relative";
 var ACTION_ADD = "add";
 var ACTION_ADD_CASED = "add-cased";
+var ACTION_ADD_RELATIVE = "add-relative";
+var ACTION_ADD_CASED_RELATIVE = "add-cased-relative";
 var ACTION_CORRECT = "enter";
 
 var CHOICE_IGNORE = { name: "Ignore", value: ACTION_IGNORE };
 var CHOICE_FILE_IGNORE = { name: "Add to file ignores", value: ACTION_FILE_IGNORE };
+var CHOICE_FILE_IGNORE_RELATIVE = { name: "[Relative] Add to file ignores", value: ACTION_FILE_IGNORE_RELATIVE };
 var CHOICE_ADD = { name: "Add to dictionary - case insensitive", value: ACTION_ADD };
 var CHOICE_ADD_CASED = { name: "Add to dictionary - case sensitive", value: ACTION_ADD_CASED };
+var CHOICE_ADD_RELATIVE = { name: "[Relative] Add to dictionary - case insensitive", value: ACTION_ADD_RELATIVE };
+var CHOICE_ADD_CASED_RELATIVE = { name: "[Relative] Add to dictionary - case sensitive", value: ACTION_ADD_CASED_RELATIVE };
 var CHOICE_CORRECT = { name: "Enter correct spelling", value: ACTION_CORRECT };
 
 var previousChoices = Object.create(null);
@@ -57,8 +69,16 @@ function incorrectWordChoices(word, message, filename, options, done) {
 
   var choices = [CHOICE_IGNORE, CHOICE_FILE_IGNORE, CHOICE_ADD, CHOICE_CORRECT];
 
+  if (options.relativeSpellingFiles) {
+    choices.splice(2, 0, CHOICE_FILE_IGNORE_RELATIVE);
+    choices.splice(4, 0, CHOICE_ADD_RELATIVE);
+  }
+
   if (word.match(/[A-Z]/)) {
     choices.splice(3, 0, CHOICE_ADD_CASED);
+    if (options.relativeSpellingFiles) {
+      choices.splice(5, 0, CHOICE_ADD_CASED_RELATIVE);
+    }
   }
 
   var defaultAction = ACTION_CORRECT;
@@ -101,12 +121,26 @@ function incorrectWordChoices(word, message, filename, options, done) {
         _spellConfig2.default.addToGlobalDictionary(word);
         done();
         break;
+      case ACTION_ADD_RELATIVE:
+        word = word.toLowerCase();
+      /* fallthrough */
+      case ACTION_ADD_CASED_RELATIVE:
+        _spellcheck2.default.addWord(word);
+        _spellConfig2.default.addToGlobalDictionary(word, true);
+        done();
+        break;
       case ACTION_CORRECT:
         getCorrectWord(word, filename, options, done);
         break;
       case ACTION_FILE_IGNORE:
         _spellcheck2.default.addWord(word, true);
         _spellConfig2.default.addToFileDictionary(filename, word);
+        previousChoices[word] = answer;
+        done();
+        break;
+      case ACTION_FILE_IGNORE_RELATIVE:
+        _spellcheck2.default.addWord(word, true);
+        _spellConfig2.default.addToFileDictionary(filename, word, true);
         previousChoices[word] = answer;
         done();
         break;

--- a/es5/cli-interactive.js
+++ b/es5/cli-interactive.js
@@ -67,10 +67,9 @@ var previousChoices = Object.create(null);
 function incorrectWordChoices(word, message, filename, options, done) {
   var suggestions = options.suggestions ? _spellcheck2.default.suggest(word) : [];
 
-  var choices = [CHOICE_IGNORE, CHOICE_FILE_IGNORE, CHOICE_ADD, CHOICE_CORRECT];
+  var choices = [CHOICE_IGNORE, options.relativeSpellingFiles ? CHOICE_FILE_IGNORE_RELATIVE : CHOICE_FILE_IGNORE, CHOICE_ADD, CHOICE_CORRECT];
 
   if (options.relativeSpellingFiles) {
-    choices.splice(2, 0, CHOICE_FILE_IGNORE_RELATIVE);
     choices.splice(4, 0, CHOICE_ADD_RELATIVE);
   }
 

--- a/es5/cli.js
+++ b/es5/cli.js
@@ -28,6 +28,10 @@ var _multiFileProcessor = require('./multi-file-processor');
 
 var _multiFileProcessor2 = _interopRequireDefault(_multiFileProcessor);
 
+var _relativeFileProcessor = require('./relative-file-processor');
+
+var _relativeFileProcessor2 = _interopRequireDefault(_relativeFileProcessor);
+
 var _spellcheck = require('./spellcheck');
 
 var _spellcheck2 = _interopRequireDefault(_spellcheck);
@@ -42,7 +46,7 @@ var buildVersion = JSON.parse(packageConfig).version;
 _commander2.default.version(buildVersion)
 // default cli behaviour will be an interactive walkthrough each error, with suggestions,
 // options to replace etc.
-.option('-r, --report', 'Outputs a full report which details the unique spelling errors found.').option('-n, --ignore-numbers', 'Ignores numbers.').option('--en-us', 'American English dictionary.').option('--en-gb', 'British English dictionary.').option('--en-au', 'Australian English dictionary.').option('--es-es', 'Spanish dictionary.').option('-d, --dictionary [file]', 'specify a custom dictionary file - it should not include the file extension and will load .dic and .aiff.').option('-a, --ignore-acronyms', 'Ignores acronyms.').option('-x, --no-suggestions', 'Do not suggest words (can be slow)').usage("[options] source-file source-file").parse(process.argv);
+.option('-r, --report', 'Outputs a full report which details the unique spelling errors found.').option('-n, --ignore-numbers', 'Ignores numbers.').option('--en-us', 'American English dictionary.').option('--en-gb', 'British English dictionary.').option('--en-au', 'Australian English dictionary.').option('--es-es', 'Spanish dictionary.').option('-d, --dictionary [file]', 'specify a custom dictionary file - it should not include the file extension and will load .dic and .aiff.').option('-a, --ignore-acronyms', 'Ignores acronyms.').option('-x, --no-suggestions', 'Do not suggest words (can be slow)').option('-t, --target-relative', 'Uses ".spelling" files relative to the target.').usage("[options] source-file source-file").parse(process.argv);
 
 var language = void 0;
 if (_commander2.default.enUs) {
@@ -59,6 +63,7 @@ var options = {
   ignoreAcronyms: _commander2.default.ignoreAcronyms,
   ignoreNumbers: _commander2.default.ignoreNumbers,
   suggestions: _commander2.default.suggestions,
+  relativeSpellingFiles: _commander2.default.targetRelative,
   dictionary: {
     language: language,
     file: _commander2.default.dictionary
@@ -73,7 +78,8 @@ if (!_commander2.default.args.length) {
   _spellcheck2.default.initialise(options);
 
   var inputPatterns = _commander2.default.args;
-  (0, _multiFileProcessor2.default)(inputPatterns, options, function (filename, src, fileProcessed) {
+  var processor = options.relativeSpellingFiles ? _relativeFileProcessor2.default : _multiFileProcessor2.default;
+  processor(inputPatterns, options, function (filename, src, fileProcessed) {
 
     if (_commander2.default.report) {
       var errors = _index2.default.spell(src, options);

--- a/es5/index.js
+++ b/es5/index.js
@@ -55,13 +55,13 @@ function spellFile(filename, options) {
 function spellCallback(src, options, callback, done) {
   var words = getWords(src, options);
 
-  _async2.default.eachSeries(words, function (wordInfo, onWordProcessed) {
+  _async2.default.eachSeries(words, _async2.default.ensureAsync(function (wordInfo, onWordProcessed) {
     if (!_spellcheck2.default.checkWord(wordInfo.word)) {
-      _async2.default.setImmediate(callback(wordInfo, onWordProcessed));
+      callback(wordInfo, onWordProcessed);
     } else {
       onWordProcessed();
     }
-  }, done);
+  }), done);
 }
 
 exports.default = { spell: spell, spellFile: spellFile, spellCallback: spellCallback, spellcheck: _spellcheck2.default, generateSummaryReport: _reportGenerator.generateSummaryReport, generateFileReport: _reportGenerator.generateFileReport };

--- a/es5/index.js
+++ b/es5/index.js
@@ -57,7 +57,7 @@ function spellCallback(src, options, callback, done) {
 
   _async2.default.eachSeries(words, function (wordInfo, onWordProcessed) {
     if (!_spellcheck2.default.checkWord(wordInfo.word)) {
-      callback(wordInfo, onWordProcessed);
+      _async2.default.setImmediate(callback(wordInfo, onWordProcessed));
     } else {
       onWordProcessed();
     }

--- a/es5/relative-file-processor.js
+++ b/es5/relative-file-processor.js
@@ -1,0 +1,75 @@
+'use strict';
+
+exports.__esModule = true;
+
+exports.default = function (inputPatterns, options, fileCallback, resultCallback) {
+  var allFiles = [];
+
+  (0, _globby2.default)(inputPatterns).then(function (files) {
+    allFiles = files;
+    spellCheckFiles();
+  }).catch(function () {
+    console.error("Error globbing:", inputPatterns);
+    process.exitCode = 1;
+  });
+
+  function spellCheckFiles() {
+    _async2.default.mapSeries(allFiles, function (file, fileProcessed) {
+      var relativeSpellingFile = _path2.default.join(_path2.default.dirname(file), ".spelling");
+      _spellConfig2.default.initialise(relativeSpellingFile, function () {
+        processFile(file, fileProcessed);
+      });
+    }, resultCallback);
+  }
+
+  function processFile(file, fileProcessed) {
+    _spellConfig2.default.getGlobalWords().forEach(function (word) {
+      return _spellcheck2.default.addWord(word);
+    });
+
+    _fs2.default.readFile(file, 'utf-8', function (err, src) {
+      if (err) {
+        console.error("Failed to open file:" + file);
+        console.error(err);
+        process.exitCode = 1;
+        return fileProcessed();
+      }
+
+      _spellConfig2.default.getFileWords(file).forEach(function (word) {
+        return _spellcheck2.default.addWord(word, true);
+      });
+
+      fileCallback(file, src, function (err, result) {
+        _spellcheck2.default.resetTemporaryCustomDictionary();
+        _spellcheck2.default.resetDictionary();
+        fileProcessed(err, result);
+      });
+    });
+  }
+};
+
+var _globby = require('globby');
+
+var _globby2 = _interopRequireDefault(_globby);
+
+var _async = require('async');
+
+var _async2 = _interopRequireDefault(_async);
+
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
+var _spellConfig = require('./spell-config');
+
+var _spellConfig2 = _interopRequireDefault(_spellConfig);
+
+var _spellcheck = require('./spellcheck');
+
+var _spellcheck2 = _interopRequireDefault(_spellcheck);
+
+var _fs = require('fs');
+
+var _fs2 = _interopRequireDefault(_fs);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/es5/relative-file-processor.js
+++ b/es5/relative-file-processor.js
@@ -41,7 +41,6 @@ exports.default = function (inputPatterns, options, fileCallback, resultCallback
 
       fileCallback(file, src, function (err, result) {
         _spellcheck2.default.resetTemporaryCustomDictionary();
-        _spellcheck2.default.resetDictionary();
         fileProcessed(err, result);
       });
     });

--- a/es5/spell-config.js
+++ b/es5/spell-config.js
@@ -6,26 +6,39 @@ var _fs = require('fs');
 
 var _fs2 = _interopRequireDefault(_fs);
 
+var _async = require('async');
+
+var _async2 = _interopRequireDefault(_async);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var fileLines = [];
 var globalDictionary = [];
 var fileDictionary = {};
-var isCrLf = false;
-var globalDictionaryIndex = -1;
+var sharedSpelling = {};
+var relativeSpelling = {};
 
-function parse() {
+function spellingFile(fileName) {
+  return {
+    fileName: fileName,
+    fileLines: [],
+    lastLineOfGlobalSpellings: -1,
+    isCrLf: false,
+    isDirty: false
+  };
+}
+
+function parse(spelling) {
   var lastNonCommentIndex = -1;
   var inGlobal = true;
   var currentFile = void 0;
-  fileLines.forEach(function (line, index) {
+  spelling.fileLines.forEach(function (line, index) {
     if (!line || line.indexOf('#') === 0) {
       return;
     }
     var fileMatch = line.match(/^\s*-\s+(.*)/);
     if (fileMatch) {
       if (inGlobal) {
-        globalDictionaryIndex = lastNonCommentIndex === -1 ? index : lastNonCommentIndex + 1;
+        spelling.lastLineOfGlobalSpellings = lastNonCommentIndex === -1 ? index : lastNonCommentIndex + 1;
         inGlobal = false;
       } else {
         fileDictionary[currentFile].index = lastNonCommentIndex + 1;
@@ -43,53 +56,83 @@ function parse() {
     lastNonCommentIndex = index;
   });
   // make sure we end on a new-line
-  if (fileLines[fileLines.length - 1]) {
-    fileLines[fileLines.length] = "";
+  if (spelling.fileLines[spelling.fileLines.length - 1]) {
+    spelling.fileLines[spelling.fileLines.length] = "";
   }
   if (inGlobal) {
-    globalDictionaryIndex = lastNonCommentIndex === -1 ? fileLines.length - 1 : lastNonCommentIndex + 1;
+    spelling.lastLineOfGlobalSpellings = lastNonCommentIndex === -1 ? spelling.fileLines.length - 1 : lastNonCommentIndex + 1;
   } else {
     fileDictionary[currentFile].index = lastNonCommentIndex;
   }
 }
 
-function emptyFile() {
-  fileLines = ["# markdown-spellcheck spelling configuration file", "# Format - lines beginning # are comments", "# global dictionary is at the start, file overrides afterwards", "# one word per line, to define a file override use ' - filename'", "# where filename is relative to this configuration file", ""];
-  globalDictionaryIndex = fileLines.length - 1;
+function emptyFile(spelling) {
+  spelling.fileLines = ["# markdown-spellcheck spelling configuration file", "# Format - lines beginning # are comments", "# global dictionary is at the start, file overrides afterwards", "# one word per line, to define a file override use ' - filename'", "# where filename is relative to this configuration file", ""];
+  spelling.lastLineOfGlobalSpellings = spelling.fileLines.length - 1;
+}
+
+function initConfig() {
+  globalDictionary = [];
+  fileDictionary = {};
+  sharedSpelling = spellingFile("./.spelling");
+  relativeSpelling = spellingFile("");
+}
+
+function loadAndParseSpelling(spelling, next) {
+  _fs2.default.readFile(spelling.fileName, { encoding: 'utf-8' }, function (err, data) {
+    if (err) {
+      emptyFile(spelling);
+      return next();
+    }
+    if (data.indexOf('\r') >= 0) {
+      spelling.isCrLf = true;
+      data = data.replace(/\r/g, "");
+    }
+
+    spelling.fileLines = data.split('\n');
+    parse(spelling);
+    return next();
+  });
 }
 
 function initialise(filename, done) {
-  _fs2.default.readFile(filename, { encoding: 'utf-8' }, function (err, data) {
-    if (err) {
-      emptyFile();
-      return done();
-    }
-    if (data.indexOf('\r') >= 0) {
-      isCrLf = true;
-      data = data.replace(/\r/g, "");
-    }
-    fileLines = data.split('\n');
-    parse();
+  initConfig();
+  relativeSpelling.fileName = filename;
+  var sharedSpellingOnly = filename === "./.spelling";
+  _async2.default.parallel([function (next) {
+    loadAndParseSpelling(sharedSpelling, next);
+  }, function (next) {
+    sharedSpellingOnly && next() || !sharedSpellingOnly && loadAndParseSpelling(relativeSpelling, next);
+  }], function () {
     return done();
   });
 }
 
-function writeFile(done) {
-  var data = fileLines.join(isCrLf ? "\r\n" : "\n");
-  _fs2.default.writeFile('./.spelling', data, function (err) {
-    if (err) {
-      console.error("Failed to save spelling file");
-      console.error(err);
-      process.exitCode = 1;
-    }
+function writeFile(done, relative) {
+  var spelling = relative ? relativeSpelling : sharedSpelling;
+  if (spelling.isDirty) {
+    var data = spelling.fileLines.join(spelling.isCrLf ? "\r\n" : "\n");
+    _fs2.default.writeFile(spelling.fileName, data, function (err) {
+      if (err) {
+        console.error("Failed to save spelling file");
+        console.error(err);
+        process.exitCode = 1;
+      } else {
+        spelling.isDirty = false;
+      }
+      done();
+    });
+  } else {
     done();
-  });
+  }
 }
 
-function addToGlobalDictionary(word) {
+function addToGlobalDictionary(word, relative) {
+  var spelling = relative ? relativeSpelling : sharedSpelling;
   globalDictionary.push(word);
-  fileLines.splice(globalDictionaryIndex, 0, word);
-  globalDictionaryIndex++;
+  spelling.fileLines.splice(spelling.lastLineOfGlobalSpellings, 0, word);
+  spelling.isDirty = true;
+  spelling.lastLineOfGlobalSpellings++;
   for (var filename in fileDictionary) {
     if (fileDictionary.hasOwnProperty(filename)) {
       fileDictionary[filename].index++;
@@ -97,10 +140,12 @@ function addToGlobalDictionary(word) {
   }
 }
 
-function addToFileDictionary(filename, word) {
+function addToFileDictionary(filename, word, relative) {
+  var spelling = relative ? relativeSpelling : sharedSpelling;
   if (fileDictionary.hasOwnProperty(filename)) {
     var fileDict = fileDictionary[filename];
-    fileLines.splice(fileDict.index, 0, word);
+    spelling.fileLines.splice(fileDict.index, 0, word);
+    spelling.isDirty = true;
     for (var dictionaryFilename in fileDictionary) {
       if (fileDictionary.hasOwnProperty(dictionaryFilename) && fileDictionary[dictionaryFilename].index >= fileDict.index) {
         fileDictionary[dictionaryFilename].index++;
@@ -108,9 +153,10 @@ function addToFileDictionary(filename, word) {
     }
     fileDict.words.push(word);
   } else {
-    fileLines.splice(fileLines.length - 1, 0, " - " + filename, word);
+    spelling.fileLines.splice(spelling.fileLines.length - 1, 0, " - " + filename, word);
+    spelling.isDirty = true;
     fileDictionary[filename] = {
-      index: fileLines.length - 1,
+      index: spelling.fileLines.length - 1,
       words: [word]
     };
   }

--- a/es6/cli-interactive.js
+++ b/es6/cli-interactive.js
@@ -8,14 +8,20 @@ import writeCorrections from './write-corrections';
 
 const ACTION_IGNORE = "ignore";
 const ACTION_FILE_IGNORE = "fileignore";
+const ACTION_FILE_IGNORE_RELATIVE = "fileignore-relative";
 const ACTION_ADD = "add";
 const ACTION_ADD_CASED = "add-cased";
+const ACTION_ADD_RELATIVE = "add-relative";
+const ACTION_ADD_CASED_RELATIVE = "add-cased-relative";
 const ACTION_CORRECT = "enter";
 
 const CHOICE_IGNORE = { name: "Ignore", value: ACTION_IGNORE };
 const CHOICE_FILE_IGNORE = { name: "Add to file ignores", value: ACTION_FILE_IGNORE };
+const CHOICE_FILE_IGNORE_RELATIVE = { name: "[Relative] Add to file ignores", value: ACTION_FILE_IGNORE_RELATIVE };
 const CHOICE_ADD = { name: "Add to dictionary - case insensitive", value: ACTION_ADD };
 const CHOICE_ADD_CASED = { name: "Add to dictionary - case sensitive", value: ACTION_ADD_CASED };
+const CHOICE_ADD_RELATIVE = { name: "[Relative] Add to dictionary - case insensitive", value: ACTION_ADD_RELATIVE };
+const CHOICE_ADD_CASED_RELATIVE = { name: "[Relative] Add to dictionary - case sensitive", value: ACTION_ADD_CASED_RELATIVE };
 const CHOICE_CORRECT = { name: "Enter correct spelling", value: ACTION_CORRECT };
 
 const previousChoices = Object.create(null);
@@ -31,8 +37,16 @@ function incorrectWordChoices(word, message, filename, options, done) {
     CHOICE_CORRECT
   ];
 
+  if (options.relativeSpellingFiles) {
+    choices.splice(2, 0, CHOICE_FILE_IGNORE_RELATIVE);
+    choices.splice(4, 0, CHOICE_ADD_RELATIVE);
+  }
+
   if (word.match(/[A-Z]/)) {
     choices.splice(3, 0, CHOICE_ADD_CASED);
+    if (options.relativeSpellingFiles) {
+      choices.splice(5, 0, CHOICE_ADD_CASED_RELATIVE);
+    }
   }
 
   let defaultAction = ACTION_CORRECT;
@@ -77,12 +91,26 @@ function incorrectWordChoices(word, message, filename, options, done) {
         spellConfig.addToGlobalDictionary(word);
         done();
         break;
+      case ACTION_ADD_RELATIVE:
+        word = word.toLowerCase();
+      /* fallthrough */
+      case ACTION_ADD_CASED_RELATIVE:
+        spellcheck.addWord(word);
+        spellConfig.addToGlobalDictionary(word, true);
+        done();
+        break;
       case ACTION_CORRECT:
         getCorrectWord(word, filename, options, done);
         break;
       case ACTION_FILE_IGNORE:
         spellcheck.addWord(word, true);
         spellConfig.addToFileDictionary(filename, word);
+        previousChoices[word] = answer;
+        done();
+        break;
+      case ACTION_FILE_IGNORE_RELATIVE:
+        spellcheck.addWord(word, true);
+        spellConfig.addToFileDictionary(filename, word, true);
         previousChoices[word] = answer;
         done();
         break;
@@ -163,6 +191,12 @@ function spellAndFixFile(filename, src, options, onFinishedFile) {
 
 export default function(file, src, options, fileProcessed) {
   spellAndFixFile(file, src, options, () => {
-    spellConfig.writeFile(fileProcessed);
+    spellConfig.writeFile(() => {
+      if (options.relativeSpellingFiles) {
+        spellConfig.writeFile(fileProcessed, true);
+      } else {
+        fileProcessed();
+      }
+    });
   });
 }

--- a/es6/cli-interactive.js
+++ b/es6/cli-interactive.js
@@ -32,13 +32,12 @@ function incorrectWordChoices(word, message, filename, options, done) {
 
   const choices = [
     CHOICE_IGNORE,
-    CHOICE_FILE_IGNORE,
+    options.relativeSpellingFiles ? CHOICE_FILE_IGNORE_RELATIVE : CHOICE_FILE_IGNORE,
     CHOICE_ADD,
     CHOICE_CORRECT
   ];
 
   if (options.relativeSpellingFiles) {
-    choices.splice(2, 0, CHOICE_FILE_IGNORE_RELATIVE);
     choices.splice(4, 0, CHOICE_ADD_RELATIVE);
   }
 

--- a/es6/cli.js
+++ b/es6/cli.js
@@ -5,6 +5,7 @@ import cliInteractive from './cli-interactive';
 import markdownSpellcheck from "./index";
 import chalk from 'chalk';
 import multiFileProcessor from './multi-file-processor';
+import relativeFileProcessor from './relative-file-processor';
 import spellcheck from './spellcheck';
 import { generateSummaryReport, generateFileReport } from './report-generator';
 
@@ -24,6 +25,7 @@ program
   .option('-d, --dictionary [file]', 'specify a custom dictionary file - it should not include the file extension and will load .dic and .aiff.')
   .option('-a, --ignore-acronyms', 'Ignores acronyms.')
   .option('-x, --no-suggestions', 'Do not suggest words (can be slow)')
+  .option('-t, --target-relative', 'Uses ".spelling" files relative to the target.')
   .usage("[options] source-file source-file")
   .parse(process.argv);
 
@@ -45,6 +47,7 @@ const options = {
   ignoreAcronyms: program.ignoreAcronyms,
   ignoreNumbers: program.ignoreNumbers,
   suggestions: program.suggestions,
+  relativeSpellingFiles: program.targetRelative,
   dictionary: {
     language: language,
     file: program.dictionary
@@ -60,7 +63,8 @@ else {
   spellcheck.initialise(options);
 
   const inputPatterns = program.args;
-  multiFileProcessor(inputPatterns, options, (filename, src, fileProcessed) => {
+  const processor = options.relativeSpellingFiles ? relativeFileProcessor : multiFileProcessor;
+  processor(inputPatterns, options, (filename, src, fileProcessed) => {
 
     if (program.report) {
       const errors = markdownSpellcheck.spell(src, options);

--- a/es6/index.js
+++ b/es6/index.js
@@ -33,7 +33,7 @@ function spellCallback(src, options, callback, done) {
 
   async.eachSeries(words, function(wordInfo, onWordProcessed) {
     if (!spellcheck.checkWord(wordInfo.word)) {
-      callback(wordInfo, onWordProcessed);
+      async.setImmediate(callback(wordInfo, onWordProcessed));
     }
     else {
       onWordProcessed();

--- a/es6/index.js
+++ b/es6/index.js
@@ -31,14 +31,14 @@ function spellFile(filename, options) {
 function spellCallback(src, options, callback, done) {
   const words = getWords(src, options);
 
-  async.eachSeries(words, function(wordInfo, onWordProcessed) {
+  async.eachSeries(words, async.ensureAsync(function(wordInfo, onWordProcessed) {
     if (!spellcheck.checkWord(wordInfo.word)) {
-      async.setImmediate(callback(wordInfo, onWordProcessed));
+      callback(wordInfo, onWordProcessed);
     }
     else {
       onWordProcessed();
     }
-  }, done);
+  }), done);
 }
 
 export default { spell, spellFile, spellCallback, spellcheck, generateSummaryReport, generateFileReport };

--- a/es6/relative-file-processor.js
+++ b/es6/relative-file-processor.js
@@ -42,7 +42,6 @@ export default function(inputPatterns, options, fileCallback, resultCallback) {
 
       fileCallback(file, src, (err, result) => {
         spellcheck.resetTemporaryCustomDictionary();
-        spellcheck.resetDictionary();
         fileProcessed(err, result);
       });
     });

--- a/es6/relative-file-processor.js
+++ b/es6/relative-file-processor.js
@@ -1,0 +1,51 @@
+import globby from 'globby';
+import async from 'async';
+import path from 'path';
+import spellConfig from './spell-config';
+import spellcheck from "./spellcheck";
+import fs from 'fs';
+
+export default function(inputPatterns, options, fileCallback, resultCallback) {
+  let allFiles = [];
+
+  globby(inputPatterns)
+    .then((files) => {
+      allFiles = files;
+      spellCheckFiles();
+    })
+    .catch(() => {
+      console.error("Error globbing:", inputPatterns);
+      process.exitCode = 1;
+    });
+
+  function spellCheckFiles() {
+    async.mapSeries(allFiles, (file, fileProcessed) => {
+      const relativeSpellingFile = path.join(path.dirname(file), ".spelling");
+      spellConfig.initialise(relativeSpellingFile, () => {
+        processFile(file, fileProcessed);
+      });
+    }, resultCallback);
+  }
+
+  function processFile(file, fileProcessed) {
+    spellConfig.getGlobalWords().forEach((word) => spellcheck.addWord(word));
+
+    fs.readFile(file, 'utf-8', (err, src) => {
+      if (err) {
+        console.error("Failed to open file:" + file);
+        console.error(err);
+        process.exitCode = 1;
+        return fileProcessed();
+      }
+
+      spellConfig.getFileWords(file).forEach((word) => spellcheck.addWord(word, true));
+
+      fileCallback(file, src, (err, result) => {
+        spellcheck.resetTemporaryCustomDictionary();
+        spellcheck.resetDictionary();
+        fileProcessed(err, result);
+      });
+    });
+  }
+
+}

--- a/es6/spell-config.js
+++ b/es6/spell-config.js
@@ -1,23 +1,33 @@
 import fs from 'fs';
+import async from 'async';
 
-let fileLines = [];
-const globalDictionary = [];
-const fileDictionary = {};
-let isCrLf = false;
-let globalDictionaryIndex = -1;
+let globalDictionary = [];
+let fileDictionary = {};
+let sharedSpelling = {};
+let relativeSpelling = {};
 
-function parse() {
+function spellingFile(fileName) {
+  return {
+    fileName,
+    fileLines: [],
+    lastLineOfGlobalSpellings: -1,
+    isCrLf: false,
+    isDirty: false
+  };
+}
+
+function parse(spelling) {
   let lastNonCommentIndex = -1;
   let inGlobal = true;
   let currentFile;
-  fileLines.forEach((line, index) => {
+  spelling.fileLines.forEach((line, index) => {
     if (!line || line.indexOf('#') === 0) {
       return;
     }
     let fileMatch = line.match(/^\s*-\s+(.*)/);
     if (fileMatch) {
       if (inGlobal) {
-        globalDictionaryIndex = lastNonCommentIndex === -1 ? index : lastNonCommentIndex + 1;
+        spelling.lastLineOfGlobalSpellings = lastNonCommentIndex === -1 ? index : lastNonCommentIndex + 1;
         inGlobal = false;
       }
       else {
@@ -38,19 +48,19 @@ function parse() {
     lastNonCommentIndex = index;
   });
   // make sure we end on a new-line
-  if (fileLines[fileLines.length - 1]) {
-    fileLines[fileLines.length] = "";
+  if (spelling.fileLines[spelling.fileLines.length - 1]) {
+    spelling.fileLines[spelling.fileLines.length] = "";
   }
   if (inGlobal) {
-    globalDictionaryIndex = lastNonCommentIndex === -1 ? fileLines.length - 1 : lastNonCommentIndex + 1;
+    spelling.lastLineOfGlobalSpellings = lastNonCommentIndex === -1 ? spelling.fileLines.length - 1 : lastNonCommentIndex + 1;
   }
   else {
     fileDictionary[currentFile].index = lastNonCommentIndex;
   }
 }
 
-function emptyFile() {
-  fileLines = [
+function emptyFile(spelling) {
+  spelling.fileLines = [
     "# markdown-spellcheck spelling configuration file",
     "# Format - lines beginning # are comments",
     "# global dictionary is at the start, file overrides afterwards",
@@ -58,41 +68,70 @@ function emptyFile() {
     "# where filename is relative to this configuration file",
     ""
   ];
-  globalDictionaryIndex = fileLines.length - 1;
+  spelling.lastLineOfGlobalSpellings = spelling.fileLines.length - 1;
+}
+
+function initConfig() {
+  globalDictionary = [];
+  fileDictionary = {};
+  sharedSpelling = spellingFile("./.spelling");
+  relativeSpelling = spellingFile("");
+}
+
+function loadAndParseSpelling(spelling, next) {
+  fs.readFile(spelling.fileName, { encoding: 'utf-8' }, (err, data) => {
+    if (err) {
+      emptyFile(spelling);
+      return next();
+    }
+    if (data.indexOf('\r') >= 0) {
+      spelling.isCrLf = true;
+      data = data.replace(/\r/g, "");
+    }
+
+    spelling.fileLines = data.split('\n');
+    parse(spelling);
+    return next();
+  });
 }
 
 function initialise(filename, done) {
-  fs.readFile(filename, { encoding: 'utf-8' }, (err, data) => {
-    if (err) {
-      emptyFile();
-      return done();
-    }
-    if (data.indexOf('\r') >= 0) {
-      isCrLf = true;
-      data = data.replace(/\r/g, "");
-    }
-    fileLines = data.split('\n');
-    parse();
+  initConfig();
+  relativeSpelling.fileName = filename;
+  const sharedSpellingOnly = filename === "./.spelling";
+  async.parallel([
+    (next) => { loadAndParseSpelling(sharedSpelling, next); },
+    (next) => { (sharedSpellingOnly && next()) || (!sharedSpellingOnly && loadAndParseSpelling(relativeSpelling, next)) }
+  ], () => {
     return done();
   });
 }
 
-function writeFile(done) {
-  const data = fileLines.join(isCrLf ? "\r\n" : "\n");
-  fs.writeFile('./.spelling', data, (err) => {
-    if (err) {
-      console.error("Failed to save spelling file");
-      console.error(err);
-      process.exitCode = 1;
-    }
+function writeFile(done, relative) {
+  const spelling = relative ? relativeSpelling : sharedSpelling;
+  if (spelling.isDirty) {
+    const data = spelling.fileLines.join(spelling.isCrLf ? "\r\n" : "\n");
+    fs.writeFile(spelling.fileName, data, (err) => {
+      if (err) {
+        console.error("Failed to save spelling file");
+        console.error(err);
+        process.exitCode = 1;
+      } else {
+        spelling.isDirty = false;
+      }
+      done();
+    });
+  } else {
     done();
-  });
+  }
 }
 
-function addToGlobalDictionary(word) {
+function addToGlobalDictionary(word, relative) {
+  const spelling = relative ? relativeSpelling : sharedSpelling;
   globalDictionary.push(word);
-  fileLines.splice(globalDictionaryIndex, 0, word);
-  globalDictionaryIndex++;
+  spelling.fileLines.splice(spelling.lastLineOfGlobalSpellings, 0, word);
+  spelling.isDirty = true;
+  spelling.lastLineOfGlobalSpellings++;
   for (let filename in fileDictionary) {
     if (fileDictionary.hasOwnProperty(filename)) {
       fileDictionary[filename].index++;
@@ -100,10 +139,12 @@ function addToGlobalDictionary(word) {
   }
 }
 
-function addToFileDictionary(filename, word) {
+function addToFileDictionary(filename, word, relative) {
+  const spelling = relative ? relativeSpelling : sharedSpelling;
   if (fileDictionary.hasOwnProperty(filename)) {
     let fileDict = fileDictionary[filename];
-    fileLines.splice(fileDict.index, 0, word);
+    spelling.fileLines.splice(fileDict.index, 0, word);
+    spelling.isDirty = true;
     for (let dictionaryFilename in fileDictionary) {
       if (fileDictionary.hasOwnProperty(dictionaryFilename) &&
       fileDictionary[dictionaryFilename].index >= fileDict.index) {
@@ -113,9 +154,10 @@ function addToFileDictionary(filename, word) {
     fileDict.words.push(word);
   }
   else {
-    fileLines.splice(fileLines.length - 1, 0, " - " + filename, word);
+    spelling.fileLines.splice(spelling.fileLines.length - 1, 0, " - " + filename, word);
+    spelling.isDirty = true;
     fileDictionary[filename] = {
-      index: fileLines.length - 1,
+      index: spelling.fileLines.length - 1,
       words: [word]
     };
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "markdown-relative-file-spellcheck",
+  "name": "markdown-spellcheck",
   "version": "1.0.0",
   "description": "Spell-checks markdown files with an interactive CLI allowing automated spell checking.",
   "keywords": [
@@ -24,10 +24,10 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jacoburton104/node-markdown-spellcheck.git"
+    "url": "https://github.com/lukeapage/node-markdown-spellcheck.git"
   },
   "bugs": {
-    "url": "https://github.com/jacoburton104/node-markdown-spellcheck/issues"
+    "url": "https://github.com/lukeapage/node-markdown-spellcheck/issues"
   },
   "dependencies": {
     "async": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "markdown-spellcheck",
+  "name": "@jburton/markdown-spellcheck",
   "version": "1.0.0",
   "description": "Spell-checks markdown files with an interactive CLI allowing automated spell checking.",
   "keywords": [
@@ -24,10 +24,10 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lukeapage/node-markdown-spellcheck.git"
+    "url": "https://github.com/jacoburton104/node-markdown-spellcheck.git"
   },
   "bugs": {
-    "url": "https://github.com/lukeapage/node-markdown-spellcheck/issues"
+    "url": "https://github.com/jacoburton104/node-markdown-spellcheck/issues"
   },
   "dependencies": {
     "async": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jburton/markdown-spellcheck",
+  "name": "markdown-relative-file-spellcheck",
   "version": "1.0.0",
   "description": "Spell-checks markdown files with an interactive CLI allowing automated spell checking.",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,14 @@ Where `speling` will be highlighted in red.
  
 All exclusions will be stored in a `.spelling` file in the directory from which you run the command.
 
+### Target Relative Mode
+
+Using the `--target-relative` (`-t`) option will augment the shared `.spelling` file with a relative `.spelling` file (sibling of the `.md` file) and give you the additional options with the interactive mode: 
+
+* "Add to file ignores" will be replaced with "[Relative] Add to file ignores". There is no need to add file ignores into the shared `.spelling` file.
+* "[Relative] Add to dictionary - case insensitive" will add to the dictionary for all files within the current .md file and match any case.
+* "[Relative] Add to dictionary - case sensitive" will add to the dictionary for all files within the folder of the current `.md` file.
+
 ### Report Mode
 
 Using the `--report` (`-r`) option will show a report of all the spelling mistakes that have been found. This mode is useful for CI build reports. 

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ All exclusions will be stored in a `.spelling` file in the directory from which 
 Using the `--target-relative` (`-t`) option will augment the shared `.spelling` file with a relative `.spelling` file (sibling of the `.md` file) and give you the additional options with the interactive mode: 
 
 * "Add to file ignores" will be replaced with "[Relative] Add to file ignores". There is no need to add file ignores into the shared `.spelling` file.
-* "[Relative] Add to dictionary - case insensitive" will add to the dictionary for all files within the current .md file and match any case.
+* "[Relative] Add to dictionary - case insensitive" will add to the dictionary for all files within the current `.md` file and match any case.
 * "[Relative] Add to dictionary - case sensitive" will add to the dictionary for all files within the folder of the current `.md` file.
 
 ### Report Mode

--- a/test/relative-file-processor.js
+++ b/test/relative-file-processor.js
@@ -1,0 +1,126 @@
+import { expect } from 'chai';
+import proxyquire from "proxyquire";
+import sinon from "sinon";
+import async from 'async';
+
+function getRelativeFileProcessor(globby, spellConfig, spellcheck) {
+  return proxyquire('../es5/relative-file-processor',
+    {
+      'globby': globby,
+      './spell-config': { default: spellConfig },
+      './spellcheck': { default: spellcheck },
+      'fs': {
+        readFile: sinon.stub().callsArg(2)
+      }
+    }).default;
+}
+
+function mockGlobby(files) {
+  return function(patterns) {
+    return {
+      then: function(cb) {
+        cb(files);
+        return this;
+      },
+      catch: function() {
+        return this;
+      }
+    };
+  };
+}
+
+function mockSpellConfig(globalWords, fileWords) {
+  var mockedSpellConfig = {
+    initialise: sinon.stub(),
+    getGlobalWords: sinon.stub().returns(globalWords || []),
+    getFileWords: sinon.stub()
+  };
+
+  if (fileWords) {
+    fileWords.forEach((fileWord, index) => {
+      mockedSpellConfig.getFileWords
+        .onCall(index)
+        .returns(fileWord);
+    });
+  } else {
+    mockedSpellConfig.getFileWords.returns([]);
+  }
+
+  mockedSpellConfig.initialise.callsArg(1);
+
+  return mockedSpellConfig;
+}
+
+function mockSpellcheck() {
+  return {
+    addWord: sinon.stub(),
+    resetTemporaryCustomDictionary: sinon.stub(),
+    resetDictionary: sinon.stub()
+  };
+}
+
+
+describe("relative-file-processor", () => {
+
+  beforeEach(() => {
+    sinon.stub(async, "setImmediate").callsArg(0);
+    sinon.stub(async, "nextTick").callsArg(0);
+  });
+  afterEach(() => {
+    async.setImmediate.restore();
+    async.nextTick.restore();
+  });
+
+  it("should work with empty patterns", () => {
+    const spellConfig = mockSpellConfig();
+    const relativeFileProcessor = getRelativeFileProcessor(mockGlobby([]), spellConfig, mockSpellcheck());
+    const fileCallSpy = sinon.stub();
+    fileCallSpy.callsArg(1);
+    const finishedSpy = sinon.spy();
+
+    relativeFileProcessor([], {}, fileCallSpy, finishedSpy);
+
+    expect(fileCallSpy.notCalled).to.equal(true);
+    expect(finishedSpy.calledOnce).to.equal(true);
+    expect(spellConfig.initialise.calledOnce).to.equal(false);
+  });
+
+  it("should work with single pattern", () => {
+    const spellConfig = mockSpellConfig();
+    const relativeFileProcessor = getRelativeFileProcessor(mockGlobby(["1"]), spellConfig, mockSpellcheck());
+    const fileCallSpy = sinon.stub();
+    fileCallSpy.callsArg(2);
+    const finishedSpy = sinon.spy();
+
+    relativeFileProcessor(["1"], {}, fileCallSpy, finishedSpy);
+
+    expect(fileCallSpy.notCalled).to.equal(false);
+    expect(finishedSpy.calledOnce).to.equal(true);
+    expect(spellConfig.initialise.calledOnce).to.equal(true);
+  });
+
+
+  it("should work with multiple patterns", () => {
+
+    const spellConfig = mockSpellConfig(["global-word"], [["word-1"], ["word-2-a", "word-2-b"], [], ["word-4"]]);
+    const spellcheck = mockSpellcheck();
+    const relativeFileProcessor = getRelativeFileProcessor(mockGlobby(["1", "2", "3", "4"]), spellConfig, spellcheck);
+    const fileCallSpy = sinon.stub();
+    fileCallSpy.callsArg(2);
+    const finishedSpy = sinon.spy();
+
+    relativeFileProcessor(["1", "2"], {}, fileCallSpy, finishedSpy);
+
+    expect(fileCallSpy.callCount).to.equal(4);
+    expect(fileCallSpy.getCall(0).args[0]).to.equal("1");
+    expect(fileCallSpy.getCall(1).args[0]).to.equal("2");
+    expect(fileCallSpy.getCall(2).args[0]).to.equal("3");
+    expect(fileCallSpy.getCall(3).args[0]).to.equal("4");
+    expect(finishedSpy.calledOnce).to.equal(true);
+    expect(spellConfig.initialise.called).to.equal(true);
+
+    //1 global word for each file, then 1 word for file 1, 2 words for file 2 and 1 word for file 4.
+    expect(spellcheck.addWord.callCount).to.equal(8);
+    expect(spellcheck.resetTemporaryCustomDictionary.callCount).to.equal(4);
+  });
+});

--- a/test/spell-config.js
+++ b/test/spell-config.js
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import sinon from "sinon";
+import proxyquire from "proxyquire";
+
+function getSpellConfig() {
+  return proxyquire('../es5/spell-config', {
+    'fs': {
+      readFile: sinon.stub().callsArgWith(2, null, ""),
+      writeFile: sinon.stub().callsArgWith(2, null)
+    }
+  }).default;
+}
+
+describe("Spell-Config", () => {
+
+  it("should initialise correctly and call done", () => {
+    const spellConfig = getSpellConfig();
+    const initDone = sinon.stub();
+    spellConfig.initialise("./.spelling", initDone);
+    expect(initDone.calledOnce).to.equal(true);
+  });
+
+  it("should add global words into array", () => {
+    const spellConfig = getSpellConfig();
+    const initDone = sinon.stub();
+    spellConfig.initialise("./.spelling", initDone);
+    spellConfig.addToGlobalDictionary("aaaaa");
+    expect(spellConfig.getGlobalWords().length).to.equal(1);
+    expect(spellConfig.getGlobalWords()[0]).to.equal("aaaaa");
+    expect(initDone.calledOnce).to.equal(true);
+  });
+
+  it("should add global words from relative or shared into array", () => {
+    const spellConfig = getSpellConfig();
+    const initDone = sinon.stub();
+    spellConfig.initialise("/relative/.spelling", initDone);
+    spellConfig.addToGlobalDictionary("aaaaa", false);
+    spellConfig.addToGlobalDictionary("bbbbb", true);
+    expect(spellConfig.getGlobalWords().length).to.equal(2);
+    expect(spellConfig.getGlobalWords()[1]).to.equal("bbbbb");
+    expect(initDone.calledOnce).to.equal(true);
+  });
+
+  it("should add file words into array", () => {
+    const FILE = "/relative/blog.md";
+    const initDone = sinon.stub();
+    const spellConfig = getSpellConfig();
+    spellConfig.initialise("./.spelling", initDone);
+    spellConfig.addToFileDictionary(FILE, "aaaaa", false);
+    expect(spellConfig.getFileWords(FILE).length).to.equal(1);
+    expect(initDone.calledOnce).to.equal(true);
+  });
+
+  it("should add file words from relative or shared into array", () => {
+    const FILE = "/relative/blog.md";
+    const initDone = sinon.stub();
+    const spellConfig = getSpellConfig();
+    spellConfig.initialise("/relative/.spelling", initDone);
+    spellConfig.addToFileDictionary(FILE, "aaaaa", false);
+    spellConfig.addToFileDictionary(FILE, "bbbbb", true);
+    expect(spellConfig.getFileWords(FILE).length).to.equal(2);
+    expect(initDone.calledOnce).to.equal(true);
+  });
+
+  it("should call done after writeFile when spelling file is dirty or clean", () => {
+    const spellConfig = getSpellConfig();
+    const initDone = sinon.stub();
+    spellConfig.initialise("./.spelling", initDone);
+    expect(initDone.calledOnce).to.equal(true);
+
+    const writeCleanFileDone = sinon.stub();
+    spellConfig.writeFile(writeCleanFileDone);
+    expect(writeCleanFileDone.calledOnce).to.equal(true);
+
+    const writeDirtyFileDone = sinon.stub();
+    spellConfig.addToGlobalDictionary("aaaaa", false);
+    spellConfig.writeFile(writeDirtyFileDone);
+    expect(writeDirtyFileDone.calledOnce).to.equal(true);
+  });
+
+});


### PR DESCRIPTION
Added a new option on the CLI "-t" or "--relative-target" which indicates the use of .spelling files relative to the folder that the ,md is stored in. The CLI Interactive also has new options displayed when this is enabled that allow you to add relative file ignores and relative dictionary additions (case sensitive and insensitive).

When relative spelling files are enabled, the processor is changed from multi-file-processor.js to relative-file-processor.js (new addition). The difference between the two is essentially the point at which the spell-config is initialised - the multi-file-processor does this once and uses the config for each file it processes whereas the relative-file-processor initialises it for each file it needs to process so that it can load the shared .spelling file (root of folder) and the relative .spelling file (could be different per file).

The spell-config has changed so that it can track both the relative and shared .spelling files. When parsing both files, all words are combined into the same array they previously were. Now the two files and their contents are individually tracked, when modifying the dictionaries, functions now take a "relative" bool parameter which indicates which spelling file It's adding to or saving.

Added a spell-config test since it didn't have one, also added a relative-file-processor test which is the same as the multi-file-processor but expects slightly different results since the call to addWord on the spellcheck increase when using the relative file processor.